### PR TITLE
Set timeout value about downloading playlist from YouTube Music

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -37,13 +37,13 @@ yoottoは「ヨーッと」って感じでサクッとYouTube Musicにアップ�
 **Posix環境の場合:**
 
 ```
-pip install https://github.com/yanoshi/yootto/releases/download/v0.1.6/yootto-0.1.6.tar.gz
+pip install https://github.com/yanoshi/yootto/releases/download/v0.1.8/yootto-0.1.8.tar.gz
 ```
 
 **Windowsの場合:**
 
 ```
-python -m pip install https://github.com/yanoshi/yootto/releases/download/v0.1.6/yootto-0.1.6.tar.gz
+python -m pip install https://github.com/yanoshi/yootto/releases/download/v0.1.8/yootto-0.1.8.tar.gz
 ```
 
 ### 認証設定:

--- a/README.md
+++ b/README.md
@@ -24,13 +24,13 @@ Using [ytmusicapi](https://github.com/sigma67/ytmusicapi). Thanks for [@sigma67]
 **In posix:**
 
 ```
-pip install https://github.com/yanoshi/yootto/releases/download/v0.1.7/yootto-0.1.7.tar.gz
+pip install https://github.com/yanoshi/yootto/releases/download/v0.1.8/yootto-0.1.8.tar.gz
 ```
 
 **In Windows:**
 
 ```
-python -m pip install https://github.com/yanoshi/yootto/releases/download/v0.1.7/yootto-0.1.6.tar.gz
+python -m pip install https://github.com/yanoshi/yootto/releases/download/v0.1.8/yootto-0.1.8.tar.gz
 ```
 
 ### Setting auth:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-ytmusicapi==0.21.0
+ytmusicapi==0.25.0
 fire==0.3.1
 tinytag==1.5.0
 tqdm==4.55.2

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ with open('requirements.txt') as requirements_file:
     install_requirements = requirements_file.read().splitlines()
 setup(
     name="yootto",
-    version="0.1.7",
+    version="0.1.8",
     description="yootto(ヨーッと) is tiny YouTube Music unofficial uploader",
     author="yanoshi",
     author_email="",

--- a/yootto/core.py
+++ b/yootto/core.py
@@ -12,6 +12,7 @@ import requests
 import datetime
 import platform
 import urllib.parse
+import functools
 
 from pathlib import Path
 from tqdm import tqdm
@@ -171,7 +172,9 @@ class Upload(object):
     ytmusic = object()
 
     try:
-      ytmusic = YTMusic(self.conf["auth_file_path"])
+      s = requests.Session()
+      s.request = functools.partial(s.request, timeout=120)
+      ytmusic = YTMusic(self.conf["auth_file_path"], requests_session=s)
     except Exception as identifier:
       return "Can not connect YouTube Music API: {}".format(identifier)
     
@@ -453,7 +456,9 @@ class Pipeline(object):
     print("Start downloading song list...")
 
     try:
-      ytmusic = YTMusic(conf_data["auth_file_path"])
+      s = requests.Session()
+      s.request = functools.partial(s.request, timeout=7200)
+      ytmusic = YTMusic(auth=conf_data["auth_file_path"], requests_session=s)
       result = ytmusic.get_library_upload_songs(100000)
     except Exception as identifier:
       return "Error: {}".format(identifier)


### PR DESCRIPTION
安定化のために諸々アップデート

- Update ytmusicapi (0.21.0 -> 0.25.0)
- プレイリストダウンロード用のタイムアウト値が設定されていなかったため明示的に設定
  - [デフォルト値は30sだった](https://ytmusicapi.readthedocs.io/en/stable/reference.html?highlight=timeout#ytmusicapi.YTMusic.__init__)